### PR TITLE
fixed contet type and uncommented used variable

### DIFF
--- a/server/MethodExecutor.cpp
+++ b/server/MethodExecutor.cpp
@@ -27,7 +27,6 @@ void	MethodExecutor::wrapperRequest(Request &requ, Response &resp)
 	resp.responseBuffer.clear();
 	resp.headerFields.clear();
 	resp.httpStatus = requ.RequestIntegrity;
-	requ.HeaderFields["content-type"] = "text/plain";
 	if (resp.httpStatus == MOVED_PERMANENTLY) {
 		resp.headerFields["location"] = requ.UsedRoute.redirect;
 	} else if (resp.httpStatus == OK_HTTP) {

--- a/server/Server.cpp
+++ b/server/Server.cpp
@@ -135,6 +135,7 @@ void Server::CheckForConnections() {
 								cleanConnection();
 							}
 						}
+						mt->second.r.HeaderFields.clear();
 					}
 				} else if (this->recievedBytes == 0) {
 					std::cout << "client sent closed connection" << std::endl;

--- a/server/Server.cpp
+++ b/server/Server.cpp
@@ -136,6 +136,7 @@ void Server::CheckForConnections() {
 							}
 						}
 						mt->second.r.HeaderFields.clear();
+						mt->second.r.RequestIntegrity = OK_HTTP;
 					}
 				} else if (this->recievedBytes == 0) {
 					std::cout << "client sent closed connection" << std::endl;

--- a/server/Server.hpp
+++ b/server/Server.hpp
@@ -42,7 +42,7 @@ private:
 
 	int socketOption;
 
-	//long int recievedBytes;
+	long int recievedBytes;
 
 	int connectionAmount;
 


### PR DESCRIPTION
Fixed:
- removed the line in method executor that was setting the content-type always to 'text/plain'
- added line in server that cleans up the request header fields after a request was processed
- uncommented recievedBytes in header file